### PR TITLE
fix false positive backtrack when start anchor at start of one side but not other

### DIFF
--- a/src/character-reader-with-references.ts
+++ b/src/character-reader-with-references.ts
@@ -207,13 +207,15 @@ export function buildCharacterReaderWithReferences(
 
           // Clear groups that are now ahead
           // This can happen when a quantifier containing a group restarts
-          if (value.subType !== 'end' && value.subType !== 'start') {
-            for (const [index, { group }] of groupContentsStore) {
-              const offset =
-                value.subType === 'null' ? value.offset : value.node.range[0];
-              if (group.range[0] >= offset) {
-                newGroupContentsStore.delete(index);
-              }
+          for (const [index, { group }] of groupContentsStore) {
+            const offset =
+              value.subType === 'null' ||
+              value.subType === 'start' ||
+              value.subType === 'end'
+                ? value.offset
+                : value.node.range[0];
+            if (group.range[0] >= offset) {
+              newGroupContentsStore.delete(index);
             }
           }
 

--- a/src/character-reader-with-references.ts
+++ b/src/character-reader-with-references.ts
@@ -41,9 +41,15 @@ export type CharacterReaderWithReferencesValueSplit = {
   type: typeof characterReaderWithReferencesTypeSplit;
 };
 
-export type ZeroWidthEntry = Readonly<{
-  groups: Groups;
-}>;
+export type ZeroWidthEntry = Readonly<
+  | {
+      groups: Groups;
+      type: 'groups';
+    }
+  | {
+      type: 'start';
+    }
+>;
 
 export type BackReferenceStack = readonly Reference[];
 export type CharacterReaderWithReferencesValueGroups = Readonly<{
@@ -103,7 +109,6 @@ function haveHadCompleteIteration(
 }
 
 type ThreadInput = Readonly<{
-  emittedSomething: boolean;
   groupContentsStore: GroupContentsStore;
   groupsWithInfiniteSize: ReadonlySet<number>;
   preceedingZeroWidthEntries: readonly ZeroWidthEntry[];
@@ -126,7 +131,6 @@ export function buildCharacterReaderWithReferences(
     preceedingZeroWidthEntries,
     quantifierIterationsAtLastGroup,
     groupsWithInfiniteSize,
-    emittedSomething,
   }: ThreadInput): CharacterReaderWithReferences {
     let next: ReaderResult<CharacterReaderValue>;
     while (!(next = threadCharacterReader.next()).done) {
@@ -137,12 +141,10 @@ export function buildCharacterReaderWithReferences(
           const _quantifierIterationsAtLastGroup =
             quantifierIterationsAtLastGroup;
           const _groupsWithInfiniteSize = groupsWithInfiniteSize;
-          const _emittedSomething = emittedSomething;
           const _preceedingZeroWidthEntries = preceedingZeroWidthEntries;
           yield {
             reader: (): CharacterReaderWithReferences =>
               startThread({
-                emittedSomething: _emittedSomething,
                 groupContentsStore: _groupContentsStore,
                 groupsWithInfiniteSize: _groupsWithInfiniteSize,
                 preceedingZeroWidthEntries: _preceedingZeroWidthEntries,
@@ -304,7 +306,6 @@ export function buildCharacterReaderWithReferences(
               );
               if (groupContents.length) {
                 for (const contents of groupContents) {
-                  emittedSomething = true;
                   yield {
                     backreferenceStack: [
                       ...contents.backreferenceStack,
@@ -332,7 +333,6 @@ export function buildCharacterReaderWithReferences(
             }
             case 'groups': {
               quantifierIterationsAtLastGroup = quantifierIterations;
-              emittedSomething = true;
 
               yield {
                 backreferenceStack: [],
@@ -352,15 +352,16 @@ export function buildCharacterReaderWithReferences(
               return 'end';
             }
             case 'start': {
-              if (emittedSomething) {
-                return 'abort';
-              }
+              preceedingZeroWidthEntries = [
+                ...preceedingZeroWidthEntries,
+                { type: 'start' },
+              ];
               break;
             }
             case 'null': {
               preceedingZeroWidthEntries = [
                 ...preceedingZeroWidthEntries,
-                { groups: value.groups },
+                { groups: value.groups, type: 'groups' },
               ];
               break;
             }
@@ -373,7 +374,6 @@ export function buildCharacterReaderWithReferences(
   };
 
   return startThread({
-    emittedSomething: false,
     groupContentsStore: new Map(),
     groupsWithInfiniteSize: new Set(),
     preceedingZeroWidthEntries: [],

--- a/src/character-reader/character-reader.ts
+++ b/src/character-reader/character-reader.ts
@@ -1,13 +1,4 @@
 import {
-  Anchor,
-  CharacterClass,
-  CharacterClassEscape,
-  Dot,
-  Reference,
-  UnicodePropertyEscape,
-  Value,
-} from 'regjsparser';
-import {
   buildGroupCharacterReader,
   Groups,
   LookaheadStack,
@@ -16,6 +7,14 @@ import {
   buildQuantifierCharacterReader,
   QuantifierStack,
 } from '../nodes/quantifier';
+import {
+  CharacterClass,
+  CharacterClassEscape,
+  Dot,
+  Reference,
+  UnicodePropertyEscape,
+  Value,
+} from 'regjsparser';
 import { buildAnchorReader } from '../nodes/anchor';
 import { buildCharacterClassCharacterReader } from '../nodes/character-class';
 import { buildCharacterClassEscapeReader } from '../nodes/character-class-escape';
@@ -63,9 +62,9 @@ export type CharacterReaderValueGroups = {
       referenceIndex: number;
       subType: 'reference';
     }
-  | { node: Anchor | null; subType: 'end' }
-  | { node: Anchor; subType: 'start' }
+  | { offset: number; subType: 'end' }
   | { offset: number; subType: 'null' }
+  | { offset: number; subType: 'start' }
 );
 
 export type CharacterReaderValue =

--- a/src/nodes/anchor.ts
+++ b/src/nodes/anchor.ts
@@ -11,7 +11,7 @@ export function* buildAnchorReader(node: Anchor): CharacterReader {
         yield {
           groups: new Map(),
           lookaheadStack: [],
-          node,
+          offset: node.range[0],
           quantifierStack: [],
           subType: 'end',
           type: characterReaderTypeCharacterEntry,
@@ -24,7 +24,7 @@ export function* buildAnchorReader(node: Anchor): CharacterReader {
       yield {
         groups: new Map(),
         lookaheadStack: [],
-        node,
+        offset: node.range[0],
         quantifierStack: [],
         subType: 'start',
         type: characterReaderTypeCharacterEntry,

--- a/src/nodes/end.ts
+++ b/src/nodes/end.ts
@@ -3,11 +3,11 @@ import {
   characterReaderTypeCharacterEntry,
 } from '../character-reader/character-reader';
 
-export function* buildEndReader(): CharacterReader {
+export function* buildEndReader(offset: number): CharacterReader {
   yield {
     groups: new Map(),
     lookaheadStack: [],
-    node: null,
+    offset,
     quantifierStack: [],
     subType: 'end',
     type: characterReaderTypeCharacterEntry,

--- a/src/nodes/group.ts
+++ b/src/nodes/group.ts
@@ -46,7 +46,7 @@ export function buildGroupCharacterReader(
                     lookaheadStack: newLookaheadStack,
                   };
                 }),
-              (): CharacterReader => buildEndReader(),
+              (): CharacterReader => buildEndReader(node.range[1]),
             ]),
           type: characterReaderTypeSplit,
         },

--- a/src/redos-detector.test.ts
+++ b/src/redos-detector.test.ts
@@ -378,6 +378,7 @@ describe('RedosDetector', () => {
         [/($)*a+a+/, false],
         [/b(a)?^\1?a?/, true],
         [/b(a)?^(a\1)(aa)?/, true],
+        [/(a)?^\1?a?/, true],
         [/(?=(a?)b)\1a?/, false],
         [/.?[a-z]?/, false],
         [/.?[^a-z]?/, false],


### PR DESCRIPTION
`/(a)?^\1?a?/` would previously fail (where `/b(a)?^\1?a?/` wouldn't)