### PR TITLE
Better atomic group detection

### DIFF
--- a/src/downgrade-pattern.test.ts
+++ b/src/downgrade-pattern.test.ts
@@ -213,6 +213,26 @@ describe('DowngradePattern', () => {
       );
       expectResult(
         downgradePattern({
+          pattern: s(/(?:(?=(a))\1)/),
+          unicode: false,
+        }),
+        {
+          atomicGroupOffsets: [10],
+          pattern: s(/(?:(?=(a))(?:a))/),
+        }
+      );
+      expectResult(
+        downgradePattern({
+          pattern: s(/((?=(a))\2){1,2}/),
+          unicode: false,
+        }),
+        {
+          atomicGroupOffsets: [8],
+          pattern: s(/((?=(a))(?:a)){1,2}/),
+        }
+      );
+      expectResult(
+        downgradePattern({
           pattern: s(/(?=(a))(?=(b\1))\2/),
           unicode: false,
         }),

--- a/src/downgrade-pattern.test.ts
+++ b/src/downgrade-pattern.test.ts
@@ -362,6 +362,7 @@ describe('DowngradePattern', () => {
         ),
         {
           references: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             '\\1': 51,
           },
           result: s(/^(?:a)b{1}c+d{1,2}e+(?:f)(?:k|l).(?:m(?:n))o+?[a\d]\1$/),
@@ -372,12 +373,14 @@ describe('DowngradePattern', () => {
           p(s(/()()()()a(\1)c(d|\2|f)(?:\3)(?:\4)+/), false)
         ),
         {
+          /* eslint-disable @typescript-eslint/naming-convention */
           references: {
             '\\1': 20,
             '\\2': 29,
             '\\3': 37,
             '\\4': 43,
           },
+          /* eslint-enable @typescript-eslint/naming-convention */
           result: s(/(?:)(?:)(?:)(?:)a(?:\1)c(?:d|\2|f)(?:\3)(?:\4)+/),
         }
       );

--- a/src/downgrade-pattern.test.ts
+++ b/src/downgrade-pattern.test.ts
@@ -273,6 +273,19 @@ describe('DowngradePattern', () => {
       );
     });
 
+    it('downgrades when group in a positive lookahead and handles nested atomic group', () => {
+      expectResult(
+        downgradePattern({
+          pattern: s(/^(?=((?=(a*))\2b*))\1c*$/),
+          unicode: false,
+        }),
+        {
+          atomicGroupOffsets: [13, 23, 26],
+          pattern: s(/^(?=((?=(a*))(?:a*)b*))(?:(?:a*)b*)c*$/),
+        }
+      );
+    });
+
     it('does not downgrade when group in a negative lookahead', () => {
       expectResult(
         downgradePattern({

--- a/src/redos-detector.test.ts
+++ b/src/redos-detector.test.ts
@@ -390,6 +390,8 @@ describe('RedosDetector', () => {
         [/a(?!(b(?=(c))))xc?\2?/, true],
         [/(a?)a?x\1/, false],
         [/(a+b)?(a+c)/, false],
+        [/(a+b)?(a+c)/, false],
+        [/^(?=((?:(?=(a*))\2.*)))\1a*$/, true],
 
         // atomic group workaround detected
         [/(?=(a{0,1}))\1a?/, true],

--- a/src/redos-detector.test.ts
+++ b/src/redos-detector.test.ts
@@ -391,7 +391,7 @@ describe('RedosDetector', () => {
         [/(a?)a?x\1/, false],
         [/(a+b)?(a+c)/, false],
         [/(a+b)?(a+c)/, false],
-        [/^(?=((?:(?=(a*))\2.*)))\1a*$/, true],
+        [/^(?=((?=(a*))\2.*))\1a*$/, true],
 
         // atomic group workaround detected
         [/(?=(a{0,1}))\1a?/, true],


### PR DESCRIPTION
- Now atomic groups in groups are found. We were tracking when a reference immediately followed a lookahead when walking through alternative nodes, but also needed to do the same when walking group nodes
- Atomic groups inside other atomic groups now work
  - Previously `^(?=((?:(?=(a*))\2.*)))\1a*$` would fail because the `\1` would be replaced with `\2.*` and that `\2` would not be considered atomic in the final `^(?=((?:(?=(a*))(?:a*).*)))(?:(?:(?:a*).*))a*$`