### PR TITLE
Discard trails with identical prefix

### DIFF
--- a/src/checker-reader.ts
+++ b/src/checker-reader.ts
@@ -145,7 +145,6 @@ export function* buildCheckerReader(input: CheckerInput): CheckerReader {
   const latestEndTime = Date.now() + input.timeout;
   let timedOut = false;
   let stackOverflow = false;
-  let infiniteResults = false;
 
   const startThread = function* ({
     leftStreamReader,
@@ -335,11 +334,10 @@ export function* buildCheckerReader(input: CheckerInput): CheckerReader {
       }
 
       if (infiniteLoopTracker.isLooping()) {
-        if (!infiniteResults) {
-          infiniteResults = true;
-          yield { type: checkerReaderTypeInfiniteLoop };
-        }
+        yield { type: checkerReaderTypeInfiniteLoop };
+        /* istanbul ignore next */
         dispose();
+        /* istanbul ignore next */
         return;
       }
 

--- a/src/collect-results.ts
+++ b/src/collect-results.ts
@@ -6,6 +6,7 @@ import {
   CheckerReaderValue,
   Trail,
 } from './checker-reader';
+import { areArraysEqual } from './arrays';
 import { buildCharacterReaderWithReferences } from './character-reader-with-references';
 import { buildNodeExtra } from './node-extra';
 import { getOrCreate } from './map';
@@ -45,41 +46,30 @@ export function collectResults({
     timeout,
   });
 
-  const trails: Trail[] = [];
+  let trails: Trail[] = [];
   const trailsByLength: Map<number, Set<Trail>> = new Map();
   let next: ReaderResult<CheckerReaderValue, CheckerReaderReturn>;
-  let potentiallyInfiniteResults = false;
   let infiniteBacktracks = false;
-
-  const calculateInfiniteBacktracks = (): void => {
-    // if the reader hit an infinite loop, but all the trails are different lengths,
-    // then there aren't infinite backtracks given the input string would be a fixed
-    // length
-    infiniteBacktracks =
-      potentiallyInfiniteResults &&
-      [...trailsByLength].some(([, trailsAtLength]) => {
-        return trailsAtLength.size > 1;
-      });
-  };
 
   outer: while (!(next = reader.next()).done) {
     switch (next.value.type) {
       case checkerReaderTypeInfiniteLoop: {
-        potentiallyInfiniteResults = true;
-        calculateInfiniteBacktracks();
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        if (infiniteBacktracks && trails.length > 0) {
+        infiniteBacktracks = true;
+        if (trails.length > 0) {
           break outer;
         }
         break;
       }
       case checkerReaderTypeTrail: {
         const trail = next.value.trail;
-        trails.push(trail);
+        trails = trails.filter((existingTrail) => {
+          const samePreix =
+            trail.length >= existingTrail.length &&
+            areArraysEqual(trail.slice(0, existingTrail.length), existingTrail);
+          return !samePreix;
+        });
+        trails = [...trails, trail];
         getOrCreate(trailsByLength, trail.length, () => new Set()).add(trail);
-        calculateInfiniteBacktracks();
-
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         if (infiniteBacktracks) {
           break outer;
         }
@@ -88,10 +78,6 @@ export function collectResults({
     }
   }
 
-  // Infinity, or get the highest number of trails that match an input string of the same length.
-  // This is not perfect (i.e `a|a|b|b` would not split 2 groups, even though if the input is `a` it could not be `b`),
-  // but the trade off is that it should be performant and never underreport
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   let worstCaseBacktrackCount = infiniteBacktracks ? Infinity : trails.length;
 
   let error: RedosDetectorError | null = null;

--- a/src/collect-results.ts
+++ b/src/collect-results.ts
@@ -9,7 +9,6 @@ import {
 import { areArraysEqual } from './arrays';
 import { buildCharacterReaderWithReferences } from './character-reader-with-references';
 import { buildNodeExtra } from './node-extra';
-import { getOrCreate } from './map';
 import { MyRootNode } from './parse';
 import { ReaderResult } from './reader';
 import { RedosDetectorError } from './redos-detector';
@@ -47,7 +46,6 @@ export function collectResults({
   });
 
   let trails: Trail[] = [];
-  const trailsByLength: Map<number, Set<Trail>> = new Map();
   let next: ReaderResult<CheckerReaderValue, CheckerReaderReturn>;
   let infiniteBacktracks = false;
 
@@ -69,7 +67,6 @@ export function collectResults({
           return !samePreix;
         });
         trails = [...trails, trail];
-        getOrCreate(trailsByLength, trail.length, () => new Set()).add(trail);
         if (infiniteBacktracks) {
           break outer;
         }

--- a/src/collect-results.ts
+++ b/src/collect-results.ts
@@ -53,10 +53,7 @@ export function collectResults({
     switch (next.value.type) {
       case checkerReaderTypeInfiniteLoop: {
         infiniteBacktracks = true;
-        if (trails.length > 0) {
-          break outer;
-        }
-        break;
+        break outer;
       }
       case checkerReaderTypeTrail: {
         const trail = next.value.trail;
@@ -67,9 +64,6 @@ export function collectResults({
           return !samePreix;
         });
         trails = [...trails, trail];
-        if (infiniteBacktracks) {
-          break outer;
-        }
         break;
       }
     }

--- a/src/nodes/quantifier.ts
+++ b/src/nodes/quantifier.ts
@@ -36,14 +36,16 @@ export function buildQuantifierIterations(
   return res;
 }
 
-// "<iteration number or * if in infinite portion>,..."
+// "<node offset>:<iteration number or * if in infinite portion>,..."
 export function buildQuantifierTrail(
   stack: QuantifierStack,
   asteriskInfinite: boolean
 ): string {
   return stack
-    .map(({ inInfinitePortion, iteration }) => {
-      return asteriskInfinite && inInfinitePortion ? '*' : `${iteration}`;
+    .map(({ quantifier, inInfinitePortion, iteration }) => {
+      return `${quantifier.range[0]}:${
+        asteriskInfinite && inInfinitePortion ? '*' : `${iteration}`
+      }`;
     })
     .join(',');
 }


### PR DESCRIPTION
and remove the logic that tried to ignore the infinite loop detection if all trails were different lengths, because even if it did work it's confusing and would work for some cases but not others.

E.g. `(a*b)?(a*c)` would work but `(a*b)+(a*c)` wouldn't