### PR TITLE
Use infinite loop detection even on finite quantifiers once passed min loops

### DIFF
--- a/src/checker-reader.ts
+++ b/src/checker-reader.ts
@@ -13,7 +13,7 @@ import {
   ReaderResult,
 } from './reader';
 import {
-  buildQuantifiersInInfinitePortion,
+  buildQuantifiersInOptionalPortion,
   buildQuantifierTrail,
   QuantifierStack,
 } from './nodes/quantifier';
@@ -285,9 +285,9 @@ export function* buildCheckerReader(input: CheckerInput): CheckerReader {
       }
 
       const leftQuantifiersInInfiniteProportion =
-        buildQuantifiersInInfinitePortion(leftValue.quantifierStack);
+        buildQuantifiersInOptionalPortion(leftValue.quantifierStack);
       const rightQuantifiersInInfiniteProportion =
-        buildQuantifiersInInfinitePortion(rightValue.quantifierStack);
+        buildQuantifiersInOptionalPortion(rightValue.quantifierStack);
 
       if (
         setsOverlap(

--- a/src/checker-reader.ts
+++ b/src/checker-reader.ts
@@ -43,6 +43,7 @@ export type CheckerInput = Readonly<{
   leftStreamReader: CharacterReaderLevel2;
   maxSteps: number;
   rightStreamReader: CharacterReaderLevel2;
+  stackOverflowLimit: number;
   timeout: number;
 }>;
 
@@ -99,8 +100,6 @@ export type CheckerReader = Reader<CheckerReaderValue, CheckerReaderReturn>;
 export type CheckerReaderReturn = Readonly<{
   error: 'hitMaxSteps' | 'stackOverflow' | 'timedOut' | null;
 }>;
-
-const stackOverflowLimit = 1000;
 
 type NodeWithQuantifierTrail = Readonly<{
   node: AstNode<MyFeatures>;
@@ -164,7 +163,7 @@ export function* buildCheckerReader(input: CheckerInput): CheckerReader {
       rightStreamReader.dispose();
     };
 
-    if (level >= stackOverflowLimit) {
+    if (level >= input.stackOverflowLimit) {
       stackOverflow = true;
     }
 

--- a/src/collect-results.ts
+++ b/src/collect-results.ts
@@ -24,6 +24,7 @@ export type CollectResultsInput = Readonly<{
   maxBacktracks: number;
   maxSteps: number;
   node: MyRootNode;
+  stackOverflowLimit: number;
   timeout: number;
 }>;
 
@@ -32,6 +33,7 @@ export function collectResults({
   node,
   maxBacktracks,
   maxSteps,
+  stackOverflowLimit,
   timeout,
 }: CollectResultsInput): WalkerResult {
   const nodeExtra = buildNodeExtra(node);
@@ -42,6 +44,7 @@ export function collectResults({
     leftStreamReader,
     maxSteps,
     rightStreamReader,
+    stackOverflowLimit,
     timeout,
   });
 

--- a/src/nodes/quantifier.ts
+++ b/src/nodes/quantifier.ts
@@ -11,19 +11,19 @@ import { Quantifier } from 'regjsparser';
 
 export type QuantifierIterations = ReadonlyMap<Quantifier<MyFeatures>, number>;
 export type QuantifierStackEntry = Readonly<{
-  inInfinitePortion: boolean;
+  inOptionalPortion: boolean;
   iteration: number;
   quantifier: Quantifier<MyFeatures>;
 }>;
 export type QuantifierStack = readonly QuantifierStackEntry[];
-export type QuantifiersInInfinitePortion = ReadonlySet<Quantifier<MyFeatures>>;
+export type QuantifiersInOptionalPortion = ReadonlySet<Quantifier<MyFeatures>>;
 
-export function buildQuantifiersInInfinitePortion(
+export function buildQuantifiersInOptionalPortion(
   stack: QuantifierStack
-): QuantifiersInInfinitePortion {
+): QuantifiersInOptionalPortion {
   return new Set(
     stack
-      .filter(({ inInfinitePortion }) => inInfinitePortion)
+      .filter(({ inOptionalPortion }) => inOptionalPortion)
       .map(({ quantifier }) => quantifier)
   );
 }
@@ -42,9 +42,9 @@ export function buildQuantifierTrail(
   asteriskInfinite: boolean
 ): string {
   return stack
-    .map(({ quantifier, inInfinitePortion, iteration }) => {
+    .map(({ quantifier, inOptionalPortion, iteration }) => {
       return `${quantifier.range[0]}:${
-        asteriskInfinite && inInfinitePortion ? '*' : `${iteration}`
+        asteriskInfinite && inOptionalPortion ? '*' : `${iteration}`
       }`;
     })
     .join(',');
@@ -79,13 +79,13 @@ export function buildQuantifierCharacterReader(
               (): CharacterReader => buildCharacterReader(node.body[0]),
             ]),
             (value) => {
-              const inInfinitePortion = i >= min && i >= 1;
+              const inOptionalPortion = i >= min && i >= 1;
               const newGroups: GroupsMutable = new Map();
               for (const [group, entry] of value.groups) {
                 newGroups.set(group, {
                   ...entry,
                   quantifierStack: [
-                    { inInfinitePortion, iteration: i, quantifier: node },
+                    { inOptionalPortion, iteration: i, quantifier: node },
                     ...entry.quantifierStack,
                   ],
                 });
@@ -94,7 +94,7 @@ export function buildQuantifierCharacterReader(
                 ...value,
                 groups: newGroups,
                 quantifierStack: [
-                  { inInfinitePortion, iteration: i, quantifier: node },
+                  { inOptionalPortion, iteration: i, quantifier: node },
                   ...value.quantifierStack,
                 ],
               };

--- a/src/nodes/quantifier.ts
+++ b/src/nodes/quantifier.ts
@@ -79,7 +79,7 @@ export function buildQuantifierCharacterReader(
               (): CharacterReader => buildCharacterReader(node.body[0]),
             ]),
             (value) => {
-              const inInfinitePortion = i >= min && i >= 1 && max === Infinity;
+              const inInfinitePortion = i >= min && i >= 1;
               const newGroups: GroupsMutable = new Map();
               for (const [group, entry] of value.groups) {
                 newGroups.set(group, {

--- a/src/redos-detector.test.ts
+++ b/src/redos-detector.test.ts
@@ -542,6 +542,14 @@ describe('RedosDetector', () => {
       ).toThrowError('`maxSteps` must be a positive number.');
     });
 
+    it('throws if `stackOverflowLimit` not positive', () => {
+      expect(() =>
+        isSafe(/a/, {
+          stackOverflowLimit: 0,
+        })
+      ).toThrowError('`stackOverflowLimit` must be a positive number.');
+    });
+
     it('throws if an unsupported flag is passed', () => {
       expect(() => isSafe(/a/i)).toThrowError('Unsupported flag: i');
     });

--- a/src/redos-detector.test.ts
+++ b/src/redos-detector.test.ts
@@ -512,8 +512,9 @@ describe('RedosDetector', () => {
     });
 
     it('returns the `stackOverflow` error if too much branching', () => {
-      const res = isSafe(/(a|b|c|d|e){1,1000}/, {
+      const res = isSafe(/a|b/, {
         maxSteps: Infinity,
+        stackOverflowLimit: 1,
       });
       expect(res.error).toBe('stackOverflow');
     });

--- a/src/redos-detector.ts
+++ b/src/redos-detector.ts
@@ -108,6 +108,13 @@ export type IsSafeConfig = {
    */
   readonly maxSteps?: number;
   /**
+   * The number of levels branching can go before a `stackOverflow` error
+   * is triggered.
+   *
+   * You shouldn't need to set this.
+   */
+  readonly stackOverflowLimit?: number;
+  /**
    * The maximum amount of time (ms) to spend processing. Once this time
    * is passed the trails found so far will be returned, and the `error`
    * will be `timeout`.
@@ -220,6 +227,7 @@ export type IsSafePatternConfig = IsSafeConfig & {
 export const defaultTimeout = Infinity;
 export const defaultMaxBacktracks = 200;
 export const defaultMaxSteps = 20000;
+export const defaultStackOverflowLimit = 1000;
 export const defaultUnicode = false;
 const supportedJSFlags: ReadonlySet<string> = new Set(['u', 'g', 's', 'y']);
 
@@ -269,6 +277,7 @@ export function isSafePattern(
     atomicGroupOffsets: atomicGroupOffsetsInput,
     maxBacktracks = defaultMaxBacktracks,
     maxSteps = defaultMaxSteps,
+    stackOverflowLimit = defaultStackOverflowLimit,
     timeout = defaultTimeout,
     unicode = defaultUnicode,
     downgradePattern = true,
@@ -288,6 +297,9 @@ export function isSafePattern(
   if (maxSteps <= 0) {
     throw new Error('`maxSteps` must be a positive number.');
   }
+  if (stackOverflowLimit <= 0) {
+    throw new Error('`stackOverflowLimit` must be a positive number.');
+  }
 
   const { pattern, atomicGroupOffsets }: PatternWithAtomicGroupOffsets =
     downgradePattern
@@ -303,6 +315,7 @@ export function isSafePattern(
     maxBacktracks,
     maxSteps,
     node: ast,
+    stackOverflowLimit,
     timeout,
   });
 


### PR DESCRIPTION
and add `stackOverflowLimit` option, which was needed for tests, but probably not in real uses.

This should make performance a lot better for things like
```regex
(a){0,9999}(a){0,9999}$
```

as it will return one trail instead of trying to collect all the possible combinations and hitting the max step limit.