### PR TITLE
Switch to `forkable-iterator` package so that GC can be automatic on `ForkableReader`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
   testEnvironment: 'node',
   rootDir: 'src',
   restoreMocks: true,
+  setupFilesAfterEnv: ['<rootDir>/jest-setup.js'],
   globals: {
     'ts-jest': {
       tsconfig: path.resolve(__dirname, './tsconfig.test.json'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "eslint": "8.21.0",
         "eslint-config-prettier": "8.5.0",
         "eslint-plugin-redos-detector": "2.0.12",
-        "forkable-iterator": "^1.1.0",
+        "forkable-iterator": "1.1.1",
         "husky": "8.0.1",
         "jest": "28.1.3",
         "lint-staged": "13.0.3",
@@ -2720,10 +2720,13 @@
       "dev": true
     },
     "node_modules/forkable-iterator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/forkable-iterator/-/forkable-iterator-1.1.0.tgz",
-      "integrity": "sha512-g0icDIC0s5Z7ePszQmLEmW+QfvGx1dnzHSHrBFgvJot8pPAThd8I6LhdkQTHBe9jq5d3zBl9620AFrBYL5trIw==",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/forkable-iterator/-/forkable-iterator-1.1.1.tgz",
+      "integrity": "sha512-VGvwj4TUrVG77y6M6C7hUkrIrDz6KfR3BF8uB+HvVzTskeRZil2GE7O+3E5pGCvoHnrDBEa33fMwYmyozgxGJQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/fs-extra": {
       "version": "10.0.0",
@@ -7627,9 +7630,9 @@
       "dev": true
     },
     "forkable-iterator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/forkable-iterator/-/forkable-iterator-1.1.0.tgz",
-      "integrity": "sha512-g0icDIC0s5Z7ePszQmLEmW+QfvGx1dnzHSHrBFgvJot8pPAThd8I6LhdkQTHBe9jq5d3zBl9620AFrBYL5trIw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/forkable-iterator/-/forkable-iterator-1.1.1.tgz",
+      "integrity": "sha512-VGvwj4TUrVG77y6M6C7hUkrIrDz6KfR3BF8uB+HvVzTskeRZil2GE7O+3E5pGCvoHnrDBEa33fMwYmyozgxGJQ==",
       "dev": true
     },
     "fs-extra": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,9 @@
         "ts-jest": "28.0.7",
         "tslib": "2.4.0",
         "typescript": "4.7.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "eslint": "8.21.0",
         "eslint-config-prettier": "8.5.0",
         "eslint-plugin-redos-detector": "2.0.12",
+        "forkable-iterator": "^1.1.0",
         "husky": "8.0.1",
         "jest": "28.1.3",
         "lint-staged": "13.0.3",
@@ -2716,6 +2717,12 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
       "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
+      "dev": true
+    },
+    "node_modules/forkable-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/forkable-iterator/-/forkable-iterator-1.1.0.tgz",
+      "integrity": "sha512-g0icDIC0s5Z7ePszQmLEmW+QfvGx1dnzHSHrBFgvJot8pPAThd8I6LhdkQTHBe9jq5d3zBl9620AFrBYL5trIw==",
       "dev": true
     },
     "node_modules/fs-extra": {
@@ -7617,6 +7624,12 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
       "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
+      "dev": true
+    },
+    "forkable-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/forkable-iterator/-/forkable-iterator-1.1.0.tgz",
+      "integrity": "sha512-g0icDIC0s5Z7ePszQmLEmW+QfvGx1dnzHSHrBFgvJot8pPAThd8I6LhdkQTHBe9jq5d3zBl9620AFrBYL5trIw==",
       "dev": true
     },
     "fs-extra": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "prepare": "husky install",
     "lint-staged": "lint-staged"
   },
+  "engines": {
+    "node": ">=14.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tjenkinson/redos-detector.git"

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "lint": "eslint --ext .ts --max-warnings 0 --cache src",
     "prettier": "prettier --write .",
     "prettier:check": "prettier --check .",
-    "test": "jest",
-    "test:ci": "jest --coverage",
+    "test": "node --expose-gc ./node_modules/.bin/jest",
+    "test:ci": "node --expose-gc ./node_modules/.bin/jest --coverage",
     "prepare": "husky install",
     "lint-staged": "lint-staged"
   },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint": "8.21.0",
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-redos-detector": "2.0.12",
-    "forkable-iterator": "^1.1.0",
+    "forkable-iterator": "1.1.1",
     "husky": "8.0.1",
     "jest": "28.1.3",
     "lint-staged": "13.0.3",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "eslint": "8.21.0",
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-redos-detector": "2.0.12",
+    "forkable-iterator": "^1.1.0",
     "husky": "8.0.1",
     "jest": "28.1.3",
     "lint-staged": "13.0.3",

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,10 @@
   "rangeStrategy": "bump",
   "packageRules": [
     {
-      "matchPackageNames": ["eslint-plugin-redos-detector"],
+      "matchPackageNames": [
+        "eslint-plugin-redos-detector",
+        "forkable-iterator"
+      ],
       "stabilityDays": 0
     },
     {

--- a/src/character-reader/character-reader-level-2.ts
+++ b/src/character-reader/character-reader-level-2.ts
@@ -23,6 +23,7 @@ import {
 } from 'regjsparser';
 import { Groups, LookaheadStack } from '../nodes/group';
 import { CharacterGroups } from '../character-groups';
+import { fork } from 'forkable-iterator';
 import { MyRootNode } from '../parse';
 import { NodeExtra } from '../node-extra';
 import { QuantifierStack } from '../nodes/quantifier';
@@ -89,7 +90,7 @@ function isReaderAtEnd(
     return false;
   };
 
-  return isAtEndUnbounded(reader.fork());
+  return isAtEndUnbounded(fork(reader));
 }
 
 /**

--- a/src/character-reader/character-reader-level-2.ts
+++ b/src/character-reader/character-reader-level-2.ts
@@ -89,10 +89,7 @@ function isReaderAtEnd(
     return false;
   };
 
-  const fork = reader.fork();
-  const atEnd = isAtEndUnbounded(fork);
-  fork.dispose();
-  return atEnd;
+  return isAtEndUnbounded(reader.fork());
 }
 
 /**

--- a/src/checker-reader.ts
+++ b/src/checker-reader.ts
@@ -30,6 +30,7 @@ import {
   CharacterReaderLevel2Value,
 } from './character-reader/character-reader-level-2';
 import { BackReferenceStack } from './character-reader/character-reader-level-1';
+import { fork } from 'forkable-iterator';
 import { InfiniteLoopTracker } from './infinite-loop-tracker';
 import { last } from './arrays';
 import { MyFeatures } from './parse';
@@ -181,7 +182,7 @@ export function* buildCheckerReader(input: CheckerInput): CheckerReader {
           leftInitial: null,
           leftStreamReader: buildForkableReader(nextLeft.value.reader()),
           level: level + 1,
-          rightStreamReader: rightStreamReader.fork(),
+          rightStreamReader: fork(rightStreamReader),
           trail,
         });
 
@@ -204,7 +205,7 @@ export function* buildCheckerReader(input: CheckerInput): CheckerReader {
           atomicGroupsInSync,
           infiniteLoopTracker: infiniteLoopTracker.clone(),
           leftInitial: nextLeft,
-          leftStreamReader: leftStreamReader.fork(),
+          leftStreamReader: fork(leftStreamReader),
           level: level + 1,
           rightStreamReader: buildForkableReader(nextRight.value.reader()),
           trail,

--- a/src/jest-setup.js
+++ b/src/jest-setup.js
@@ -2,6 +2,8 @@ afterAll(() => {
   // prevents
   // "A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks. Active timers can also cause this, ensure that .unref() was called on them."
   // happening
-  // My theory is without the forced GC the `FinalisationRegistry` we use hasn't run for everything yet and jest thinks the `heldValue`'s registered there are leaks
+  // This seems to be because the process is taking too long to terminate, as a result of GC taking too long during the timeout period
+  // Doing this moves the GC to before the request for the process to stop where the timeout is running
+  // See https://github.com/facebook/jest/pull/13139
   global.gc?.();
 });

--- a/src/jest-setup.js
+++ b/src/jest-setup.js
@@ -1,0 +1,7 @@
+afterAll(() => {
+  // prevents
+  // "A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks. Active timers can also cause this, ensure that .unref() was called on them."
+  // happening
+  // My theory is without the forced GC the `FinalisationRegistry` we use hasn't run for everything yet and jest thinks the `heldValue`'s registered there are leaks
+  global.gc?.();
+});

--- a/src/reader.test.ts
+++ b/src/reader.test.ts
@@ -1,60 +1,6 @@
-import {
-  buildArrayReader,
-  buildForkableReader,
-  chainReaders,
-  emptyReader,
-  ForkableReader,
-} from './reader';
-
-if (!global.gc) {
-  throw new Error('node --expose-gc flag required');
-}
-
-const gc: () => void = global.gc;
+import { buildArrayReader, chainReaders, emptyReader } from './reader';
 
 describe('Reader', () => {
-  describe('ForkableReader', () => {
-    let reader: ForkableReader<number, void>;
-    beforeEach(() => {
-      reader = buildForkableReader(buildArrayReader([1, 2, 3]));
-    });
-
-    it('yields the correct items', () => {
-      const fork = reader.fork();
-      expect(fork.next().value).toBe(1);
-      expect(fork.next().value).toBe(2);
-
-      expect(reader.next().value).toBe(1);
-
-      const fork2 = reader.fork();
-      expect(reader.next().value).toBe(2);
-
-      expect(fork2.next().value).toBe(2);
-
-      expect(reader.next().value).toBe(3);
-      expect(reader.next().value).toBe(undefined);
-
-      expect(fork.next().value).toBe(3);
-      expect(fork.next().value).toBe(undefined);
-
-      expect(fork2.next().value).toBe(3);
-      expect(fork2.next().value).toBe(undefined);
-    });
-
-    it('gcs a fork when it is no longer referenced', async () => {
-      const fork = reader.fork();
-      fork.next();
-
-      const fork2 = new WeakRef(reader.fork());
-
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      gc();
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
-      expect(fork2.deref()).toBe(undefined);
-    });
-  });
-
   describe('chainReaders()', () => {
     it('yields the correct items', () => {
       const reader = chainReaders([

--- a/src/reader.test.ts
+++ b/src/reader.test.ts
@@ -1,6 +1,8 @@
 import {
   buildArrayReader,
   buildForkableReader,
+  chainReaders,
+  emptyReader,
   ForkableReader,
 } from './reader';
 
@@ -50,6 +52,26 @@ describe('Reader', () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       expect(fork2.deref()).toBe(undefined);
+    });
+  });
+
+  describe('chainReaders()', () => {
+    it('yields the correct items', () => {
+      const reader = chainReaders([
+        buildArrayReader([0, 1]),
+        buildArrayReader([2, 3]),
+      ]);
+      expect(reader.next().value).toBe(0);
+      expect(reader.next().value).toBe(1);
+      expect(reader.next().value).toBe(2);
+      expect(reader.next().value).toBe(3);
+      expect(reader.next().done).toBe(true);
+    });
+  });
+
+  describe('emptyReader()', () => {
+    it('is immediately done', () => {
+      expect(emptyReader().next().done).toBe(true);
     });
   });
 });

--- a/src/reader.test.ts
+++ b/src/reader.test.ts
@@ -45,8 +45,9 @@ describe('Reader', () => {
 
       const fork2 = new WeakRef(reader.fork());
 
-      await new Promise((resolve) => process.nextTick(resolve));
+      await new Promise((resolve) => setTimeout(resolve, 0));
       gc();
+      await new Promise((resolve) => setTimeout(resolve, 0));
 
       expect(fork2.deref()).toBe(undefined);
     });

--- a/src/reader.ts
+++ b/src/reader.ts
@@ -1,15 +1,12 @@
+import { buildForkableIterator, ForkableIterator } from 'forkable-iterator';
+
 export type Reader<T, TReturn = void> = Iterator<T, TReturn>;
 export type ReaderResult<T, TReturn = void> = IteratorResult<T, TReturn>;
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 export function* emptyReader<T>(): Reader<T> {}
 
-const pendingItemsSymbol = Symbol('pendingItems');
-
-export type ForkableReader<T, TReturn = void> = Reader<T, TReturn> & {
-  fork(): ForkableReader<T, TReturn>;
-  [pendingItemsSymbol]: T[];
-};
+export type ForkableReader<T, TReturn = void> = ForkableIterator<T, TReturn>;
 
 /**
  * Returns a reader that can be forked with the `fork` function.
@@ -19,63 +16,7 @@ export type ForkableReader<T, TReturn = void> = Reader<T, TReturn> & {
 export function buildForkableReader<T, TReturn = void>(
   sourceReader: Reader<T, TReturn>
 ): ForkableReader<T, TReturn> {
-  const onItem: Array<(item: T) => void> = [];
-  let sourceDone = false;
-  let returnVal: TReturn;
-
-  const registry = new FinalizationRegistry<(item: T) => void>(
-    (onItemCallback) => {
-      const index = onItem.indexOf(onItemCallback);
-      if (index >= 0) onItem.splice(index, 1);
-    }
-  );
-
-  const readSource = (): void => {
-    if (sourceDone) return;
-    const result = sourceReader.next();
-    if (!result.done) {
-      onItem.forEach((fn) => fn(result.value));
-    } else {
-      onItem.splice(0, onItem.length);
-      sourceDone = true;
-      returnVal = result.value;
-    }
-  };
-
-  const makeFork = (initialPendingItems: T[]): ForkableReader<T, TReturn> => {
-    const reader: ForkableReader<T, TReturn> = {
-      fork() {
-        return makeFork(this[pendingItemsSymbol]);
-      },
-      next(): ReaderResult<T, TReturn> {
-        const pendingItems = this[pendingItemsSymbol];
-        if (!pendingItems.length) {
-          readSource();
-        }
-        if (pendingItems.length) {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          return { value: pendingItems.shift()! };
-        }
-        return { done: true, value: returnVal };
-      },
-      [pendingItemsSymbol]: [...initialPendingItems],
-    };
-
-    if (!sourceDone) {
-      const ref = new WeakRef(reader);
-      const callback = (item: T): void => {
-        const maybeReader = ref.deref();
-        /* istanbul ignore next */
-        maybeReader?.[pendingItemsSymbol].push(item);
-      };
-      registry.register(reader, callback);
-      onItem.push(callback);
-    }
-
-    return reader;
-  };
-
-  return makeFork([]);
+  return buildForkableIterator(sourceReader);
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "ESNext",
     "target": "ES5",
-    "lib": ["dom", "es2019", "ESNext.WeakRef"],
+    "lib": ["dom", "es2019"],
     "types": ["node"],
     "rootDir": "src",
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "ESNext",
     "target": "ES5",
-    "lib": ["dom", "es2019"],
+    "lib": ["dom", "es2019", "ESNext.WeakRef"],
     "types": ["node"],
     "rootDir": "src",
     "strict": true,

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "types": ["jest"]
+    "types": ["jest", "node"]
   },
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
This means we can remove the `dispose()` function and have the cleanup happen automatically.

Without this logic all forks of a source reader will stay alive whilst the source is not ended (unless the previous `dispose()` function was called) because they are all waiting to be notified of new messages. Any fork that is behind will keep all messages that are pending alive too.

This is supported in all major browsers and from node 14 onwards.

The logic in this PR was moved into https://github.com/tjenkinson/forkable-iterator