### PR TITLE
Fix case insensitive not working properly for a few characters

### DIFF
--- a/src/code-point.test.ts
+++ b/src/code-point.test.ts
@@ -1,58 +1,83 @@
 import { buildCodePointRanges, toCodePoint } from './code-point';
 
+function cp(input: string): number {
+  const codePoint = toCodePoint(input);
+  if (codePoint === null) throw new Error('Did not map to one code point');
+  return codePoint;
+}
+
 describe('CodePoint', () => {
   describe('buildRanges', () => {
     it('works', () => {
       expect(
         buildCodePointRanges({
           caseInsensitive: true,
-          highCodePoint: toCodePoint('a'),
-          lowCodePoint: toCodePoint('a'),
+          highCodePoint: cp('a'),
+          lowCodePoint: cp('a'),
         }),
-      ).toStrictEqual([[toCodePoint('a'), toCodePoint('a')]]);
+      ).toStrictEqual([[cp('A'), cp('A')]]);
 
       expect(
         buildCodePointRanges({
           caseInsensitive: true,
-          highCodePoint: toCodePoint('a'),
-          lowCodePoint: toCodePoint('A'),
+          highCodePoint: cp('a'),
+          lowCodePoint: cp('A'),
         }),
-      ).toStrictEqual([[toCodePoint('['), toCodePoint('z')]]);
+      ).toStrictEqual([[cp('A'), cp('`')]]);
 
       expect(
         buildCodePointRanges({
           caseInsensitive: true,
-          highCodePoint: toCodePoint('a'),
-          lowCodePoint: toCodePoint('C'),
+          highCodePoint: cp('a'),
+          lowCodePoint: cp('C'),
         }),
       ).toStrictEqual([
-        [toCodePoint('['), toCodePoint('a')],
-        [toCodePoint('c'), toCodePoint('z')],
+        [cp('A'), cp('A')],
+        [cp('C'), cp('`')],
       ]);
 
       expect(
         buildCodePointRanges({
           caseInsensitive: true,
-          highCodePoint: toCodePoint(']'),
-          lowCodePoint: toCodePoint('['),
+          highCodePoint: cp(']'),
+          lowCodePoint: cp('['),
         }),
-      ).toStrictEqual([[toCodePoint('['), toCodePoint(']')]]);
+      ).toStrictEqual([[cp('['), cp(']')]]);
 
       expect(
         buildCodePointRanges({
           caseInsensitive: true,
-          highCodePoint: toCodePoint('}'),
-          lowCodePoint: toCodePoint('Z'),
+          highCodePoint: cp('}'),
+          lowCodePoint: cp('Z'),
         }),
-      ).toStrictEqual([[toCodePoint('['), toCodePoint('}')]]);
+      ).toStrictEqual([
+        [cp('A'), cp('`')],
+        [cp('{'), cp('}')],
+      ]);
 
       expect(
         buildCodePointRanges({
           caseInsensitive: false,
-          highCodePoint: toCodePoint('}'),
-          lowCodePoint: toCodePoint('Z'),
+          highCodePoint: cp('}'),
+          lowCodePoint: cp('Z'),
         }),
-      ).toStrictEqual([[toCodePoint('Z'), toCodePoint('}')]]);
+      ).toStrictEqual([[cp('Z'), cp('}')]]);
+
+      expect(
+        buildCodePointRanges({
+          caseInsensitive: true,
+          highCodePoint: cp('Ω'),
+          lowCodePoint: cp('Ω'),
+        }),
+      ).toStrictEqual([[cp('Ω'), cp('Ω')]]);
+
+      expect(
+        buildCodePointRanges({
+          caseInsensitive: true,
+          highCodePoint: cp('ß'),
+          lowCodePoint: cp('ß'),
+        }),
+      ).toStrictEqual([[cp('ß'), cp('ß')]]);
     });
   });
 });

--- a/src/code-point.ts
+++ b/src/code-point.ts
@@ -1,14 +1,20 @@
 import { createRanges, OurRange } from './our-range';
 
-export function toCodePoint(input: string): number {
+export function toCodePoint(input: string): number | null {
+  // https://tc39.es/ecma262/multipage/text-processing.html#sec-runtime-semantics-canonicalize-ch
+  // step 7
+  if (input.length > 1) return null;
+
   const codePoint = input.codePointAt(0);
   /* istanbul ignore next */
   if (!codePoint) throw new Error('Internal error: expected codepoint');
   return codePoint;
 }
 
-export function toLowerCaseCodePoint(codePoint: number): number {
-  return toCodePoint(String.fromCodePoint(codePoint).toLowerCase());
+export function toUpperCaseCodePoint(codePoint: number): number {
+  const upperCase = String.fromCodePoint(codePoint).toUpperCase();
+  const upperCodePoint = toCodePoint(upperCase);
+  return upperCodePoint !== null ? upperCodePoint : codePoint;
 }
 
 export function buildCodePointRanges({
@@ -26,7 +32,7 @@ export function buildCodePointRanges({
 
   const codePoints: Set<number> = new Set();
   for (let codePoint = lowCodePoint; codePoint <= highCodePoint; codePoint++) {
-    codePoints.add(toLowerCaseCodePoint(codePoint));
+    codePoints.add(toUpperCaseCodePoint(codePoint));
   }
 
   return createRanges(codePoints);

--- a/src/nodes/character-class.ts
+++ b/src/nodes/character-class.ts
@@ -48,13 +48,7 @@ export function buildCharacterClassCharacterReader({
       case 'characterClassEscape': {
         const range = characterClassEscapeToRange(expression.value);
         if (range) {
-          characterGroups.ranges.push(
-            ...buildCodePointRanges({
-              caseInsensitive,
-              highCodePoint: range[1],
-              lowCodePoint: range[0],
-            }),
-          );
+          characterGroups.ranges.push(range);
         } else {
           characterGroups.characterClassEscapes.add(expression.value);
         }

--- a/src/nodes/value.ts
+++ b/src/nodes/value.ts
@@ -4,7 +4,7 @@ import {
   CharacterReaderValueGroups,
 } from '../character-reader/character-reader-level-0';
 import { buildArrayReader } from '../reader';
-import { toLowerCaseCodePoint } from '../code-point';
+import { toUpperCaseCodePoint } from '../code-point';
 import { Value } from 'regjsparser';
 
 export function codePointFromValue({
@@ -16,7 +16,7 @@ export function codePointFromValue({
 }): number {
   const codePoint = value.codePoint;
 
-  return caseInsensitive ? toLowerCaseCodePoint(codePoint) : codePoint;
+  return caseInsensitive ? toUpperCaseCodePoint(codePoint) : codePoint;
 }
 
 export function buildValueCharacterReader({


### PR DESCRIPTION
The spec says internally it should use `.toUpperCase` not `toLowerCase`, and also in cases where `toUpperCase` results in multiple code points (e.g. `ß`), the initial codepoint should be used.