### PR TITLE
Handle all none unicode character class escapes natively

### DIFF
--- a/src/checker-reader.ts
+++ b/src/checker-reader.ts
@@ -326,7 +326,8 @@ export function* buildCheckerReader(input: CheckerInput): CheckerReader {
     }
 
     const intersection = intersectCharacterGroups(
-      [leftValue, rightValue].map(({ characterGroups }) => characterGroups),
+      leftValue.characterGroups,
+      rightValue.characterGroups,
     );
 
     if (isEmptyCharacterGroups(intersection)) {

--- a/src/code-point.ts
+++ b/src/code-point.ts
@@ -25,7 +25,7 @@ export function buildCodePointRanges({
   caseInsensitive: boolean;
   highCodePoint: number;
   lowCodePoint: number;
-}): OurRange[] {
+}): readonly OurRange[] {
   if (!caseInsensitive) {
     return [[lowCodePoint, highCodePoint]];
   }

--- a/src/nodes/character-class-escape.ts
+++ b/src/nodes/character-class-escape.ts
@@ -2,27 +2,71 @@ import {
   CharacterReader,
   characterReaderTypeCharacterEntry,
 } from '../character-reader/character-reader-level-0';
+import { invertRanges, OurRange } from '../our-range';
 import { CharacterClassEscape } from 'regjsparser';
-import { OurRange } from '../our-range';
 
-export function characterClassEscapeToRange(value: string): OurRange | null {
-  if (value === 'd') {
-    // [0-9]
-    return [48, 57];
+export type CharacterClassEscapeValue = 'd' | 'D' | 'w' | 'W' | 's' | 'S';
+
+// [0-9]
+const dRanges: readonly OurRange[] = [[48, 57]];
+const inverseDRanges = invertRanges(dRanges);
+
+// [A-Za-z0-9_]
+const wRanges: readonly OurRange[] = [
+  [48, 57],
+  [65, 90],
+  [95, 95],
+  [97, 122],
+];
+const inverseWRanges = invertRanges(wRanges);
+
+// [\f\n\r\t\v\u0020\u00a0\u1680\u2000-\u200a\u2028-\u2029\u202f\u205f\u3000\ufeff]
+const sRanges: readonly OurRange[] = [
+  [9, 9],
+  [10, 10],
+  [11, 11],
+  [12, 12],
+  [13, 13],
+  [32, 32],
+  [160, 160],
+  [5760, 5760],
+  [8192, 8202],
+  [8232, 8233],
+  [8239, 8239],
+  [8287, 8287],
+  [12288, 12288],
+  [65279, 65279],
+];
+const inverseSRanges = invertRanges(sRanges);
+
+export function characterClassEscapeToRange(
+  value: CharacterClassEscapeValue,
+): readonly OurRange[] {
+  switch (value) {
+    case 'd':
+    case 'D': {
+      return value === 'd' ? dRanges : inverseDRanges;
+    }
+    case 'w':
+    case 'W': {
+      return value === 'w' ? wRanges : inverseWRanges;
+    }
+    case 's':
+    case 'S': {
+      return value === 's' ? sRanges : inverseSRanges;
+    }
   }
-  return null;
 }
 
 export function* buildCharacterClassEscapeReader(
   node: CharacterClassEscape,
 ): CharacterReader {
-  const range = characterClassEscapeToRange(node.value);
+  const value = node.value as CharacterClassEscapeValue;
+  const ranges = characterClassEscapeToRange(value);
   yield {
     characterGroups: {
-      characterClassEscapes: new Set(range ? [] : [node.value]),
-      dot: false,
       negated: false,
-      ranges: range ? [range] : [],
+      ranges,
       unicodePropertyEscapes: new Set(),
     },
     node,

--- a/src/nodes/character-class.ts
+++ b/src/nodes/character-class.ts
@@ -1,4 +1,8 @@
 import {
+  characterClassEscapeToRange,
+  CharacterClassEscapeValue,
+} from './character-class-escape';
+import {
   CharacterReader,
   characterReaderTypeCharacterEntry,
   CharacterReaderValueGroups,
@@ -6,7 +10,6 @@ import {
 import { buildArrayReader } from '../reader';
 import { buildCodePointRanges } from '../code-point';
 import { CharacterClass } from 'regjsparser';
-import { characterClassEscapeToRange } from './character-class-escape';
 import { codePointFromValue } from './value';
 import { MutableCharacterGroups } from '../character-groups';
 
@@ -18,7 +21,6 @@ export function buildCharacterClassCharacterReader({
   node: CharacterClass;
 }): CharacterReader {
   const characterGroups: MutableCharacterGroups = {
-    characterClassEscapes: new Set(),
     dot: false,
     negated: !!node.negative,
     ranges: [],
@@ -46,12 +48,9 @@ export function buildCharacterClassCharacterReader({
         break;
       }
       case 'characterClassEscape': {
-        const range = characterClassEscapeToRange(expression.value);
-        if (range) {
-          characterGroups.ranges.push(range);
-        } else {
-          characterGroups.characterClassEscapes.add(expression.value);
-        }
+        const value = expression.value as CharacterClassEscapeValue;
+        const ranges = characterClassEscapeToRange(value);
+        characterGroups.ranges.push(...ranges);
         break;
       }
       case 'unicodePropertyEscape': {

--- a/src/nodes/dot.ts
+++ b/src/nodes/dot.ts
@@ -7,10 +7,13 @@ import { Dot } from 'regjsparser';
 export function* buildDotCharacterReader(node: Dot): CharacterReader {
   yield {
     characterGroups: {
-      characterClassEscapes: new Set(),
-      dot: true,
-      negated: false,
-      ranges: [],
+      negated: true,
+      // [\n\r\u2028-\u2029]
+      ranges: [
+        [10, 10],
+        [13, 13],
+        [8232, 8233],
+      ],
       unicodePropertyEscapes: new Set(),
     },
     node,

--- a/src/nodes/unicode-property-escape.ts
+++ b/src/nodes/unicode-property-escape.ts
@@ -12,8 +12,6 @@ export function buildUnicodePropertyEscapeCharacterReader(
   return buildArrayReader<CharacterReaderValueGroups>([
     {
       characterGroups: {
-        characterClassEscapes: new Set(),
-        dot: false,
         negated: node.negative,
         ranges: [],
         unicodePropertyEscapes: new Set([node.value]),

--- a/src/nodes/value.ts
+++ b/src/nodes/value.ts
@@ -30,8 +30,6 @@ export function buildValueCharacterReader({
   return buildArrayReader<CharacterReaderValueGroups>([
     {
       characterGroups: {
-        characterClassEscapes: new Set(),
-        dot: false,
         negated: false,
         ranges: [[codePoint, codePoint]],
         unicodePropertyEscapes: new Set(),

--- a/src/our-range.test.ts
+++ b/src/our-range.test.ts
@@ -1,68 +1,91 @@
-import { createRanges, intersectRanges, subtractRanges } from './our-range';
+import {
+  createRanges,
+  intersectRanges,
+  invertRanges,
+  subtractRanges,
+} from './our-range';
 
 describe('OurRange', () => {
   describe('intersectRanges', () => {
     it('works', () => {
       expect(intersectRanges([0, 1], [2, 3])).toBe(null);
+      expect(intersectRanges([1, 1], [1, 1])).toStrictEqual([1, 1]);
+      expect(intersectRanges([0, 1], [1, 2])).toStrictEqual([1, 1]);
+      expect(intersectRanges([1, 2], [0, 3])).toStrictEqual([1, 2]);
+      expect(intersectRanges([1, 4], [3, 6])).toStrictEqual([3, 4]);
+    });
 
-      expect(intersectRanges([1, 1], [1, 1])).toStrictEqual({
-        a: [],
-        b: [],
-        shared: [1, 1],
-      });
-
-      expect(intersectRanges([0, 1], [1, 2])).toStrictEqual({
-        a: [[0, 0]],
-        b: [[2, 2]],
-        shared: [1, 1],
-      });
-
-      expect(intersectRanges([1, 2], [0, 3])).toStrictEqual({
-        a: [],
-        b: [
+    describe('subtractRanges', () => {
+      it('works', () => {
+        expect(subtractRanges([1, 3], [1, 3])).toStrictEqual([]);
+        expect(subtractRanges([1, 3], [1, 2])).toStrictEqual([[3, 3]]);
+        expect(subtractRanges([0, 3], [1, 2])).toStrictEqual([
           [0, 0],
           [3, 3],
-        ],
-        shared: [1, 2],
-      });
-
-      expect(intersectRanges([1, 4], [3, 6])).toStrictEqual({
-        a: [[1, 2]],
-        b: [[5, 6]],
-        shared: [3, 4],
+        ]);
+        expect(subtractRanges([0, 5], [2, 3])).toStrictEqual([
+          [0, 1],
+          [4, 5],
+        ]);
       });
     });
-  });
 
-  describe('subtractRanges', () => {
-    it('works', () => {
-      expect(subtractRanges([1, 3], [1, 3])).toStrictEqual([]);
-      expect(subtractRanges([1, 3], [1, 2])).toStrictEqual([[3, 3]]);
-      expect(subtractRanges([0, 3], [1, 2])).toStrictEqual([
-        [0, 0],
-        [3, 3],
-      ]);
-      expect(subtractRanges([0, 5], [2, 3])).toStrictEqual([
-        [0, 1],
-        [4, 5],
-      ]);
+    describe('createRanges', () => {
+      it('works', () => {
+        expect(createRanges(new Set())).toStrictEqual([]);
+        expect(createRanges(new Set([1]))).toStrictEqual([[1, 1]]);
+        expect(createRanges(new Set([1, 2]))).toStrictEqual([[1, 2]]);
+        expect(createRanges(new Set([1, 3]))).toStrictEqual([
+          [1, 1],
+          [3, 3],
+        ]);
+        expect(createRanges(new Set([1, 2, 3]))).toStrictEqual([[1, 3]]);
+        expect(createRanges(new Set([5, 4, 1, 0]))).toStrictEqual([
+          [0, 1],
+          [4, 5],
+        ]);
+      });
     });
-  });
 
-  describe('createRanges', () => {
-    it('works', () => {
-      expect(createRanges(new Set())).toStrictEqual([]);
-      expect(createRanges(new Set([1]))).toStrictEqual([[1, 1]]);
-      expect(createRanges(new Set([1, 2]))).toStrictEqual([[1, 2]]);
-      expect(createRanges(new Set([1, 3]))).toStrictEqual([
-        [1, 1],
-        [3, 3],
-      ]);
-      expect(createRanges(new Set([1, 2, 3]))).toStrictEqual([[1, 3]]);
-      expect(createRanges(new Set([5, 4, 1, 0]))).toStrictEqual([
-        [0, 1],
-        [4, 5],
-      ]);
+    describe('invertRanges', () => {
+      it('works', () => {
+        expect(invertRanges([])).toStrictEqual([[-Infinity, Infinity]]);
+        expect(invertRanges([[0, 0]])).toStrictEqual([
+          [-Infinity, -1],
+          [1, Infinity],
+        ]);
+        expect(invertRanges([[1, 2]])).toStrictEqual([
+          [-Infinity, 0],
+          [3, Infinity],
+        ]);
+        expect(
+          invertRanges([
+            [1, 2],
+            [3, 4],
+          ]),
+        ).toStrictEqual([
+          [-Infinity, 0],
+          [5, Infinity],
+        ]);
+        expect(
+          invertRanges([
+            [1, 2],
+            [4, 6],
+            [10, 12],
+          ]),
+        ).toStrictEqual([
+          [-Infinity, 0],
+          [3, 3],
+          [7, 9],
+          [13, Infinity],
+        ]);
+      });
+      expect(() =>
+        invertRanges([
+          [1, 1],
+          [0, 0],
+        ]),
+      ).toThrowError('Internal error: invalid ranges input');
     });
   });
 });

--- a/src/our-range.ts
+++ b/src/our-range.ts
@@ -1,11 +1,5 @@
 export type OurRange = readonly [number, number];
 
-export type RangeIntersection = Readonly<{
-  a: readonly OurRange[];
-  b: readonly OurRange[];
-  shared: OurRange;
-}>;
-
 export function subtractRanges(
   source: OurRange,
   toSubtract: OurRange,
@@ -20,25 +14,17 @@ export function subtractRanges(
   return res;
 }
 
-export function intersectRanges(
-  a: OurRange,
-  b: OurRange,
-): RangeIntersection | null {
+export function intersectRanges(a: OurRange, b: OurRange): OurRange | null {
   const startShared = Math.max(a[0], b[0]);
   const endShared = Math.min(a[1], b[1]);
   if (startShared > endShared) {
     return null;
   }
 
-  const shared: OurRange = [startShared, endShared];
-  return {
-    a: subtractRanges(a, shared),
-    b: subtractRanges(b, shared),
-    shared,
-  };
+  return [startShared, endShared];
 }
 
-export function createRanges(set: Set<number>): OurRange[] {
+export function createRanges(set: ReadonlySet<number>): readonly OurRange[] {
   const ascending = [...set].sort((a, b) => a - b);
 
   const ranges: OurRange[] = [];
@@ -56,4 +42,23 @@ export function createRanges(set: Set<number>): OurRange[] {
   }
 
   return ranges;
+}
+
+/* note input ranges must be sorted and not overlap */
+export function invertRanges(ranges: readonly OurRange[]): readonly OurRange[] {
+  const result: OurRange[] = [];
+
+  for (let i = 0; i < ranges.length + 1; i++) {
+    const prev = i - 1 >= 0 ? ranges[i - 1] : null;
+    const current = i < ranges.length ? ranges[i] : null;
+
+    const start = prev ? prev[1] + 1 : -Infinity;
+    const end = current ? current[0] - 1 : +Infinity;
+    if (start - end === 1) continue;
+    if (start > end) throw new Error('Internal error: invalid ranges input');
+
+    result.push([start, end]);
+  }
+
+  return result;
 }

--- a/src/redos-detector.test.ts
+++ b/src/redos-detector.test.ts
@@ -93,7 +93,11 @@ describe('RedosDetector', () => {
         [/[^]+a*$/, false],
         [/\d+[0-9]*$/, false],
         [/[^\d]+[0-9]*$/, true],
-        [/[^\w]+a*$/, false],
+        [/\D+[0-9]*$/, true],
+        [/[\D\d]+[0-9]*$/, false],
+        [/[\D1]+[0-9]*$/, false],
+        [/\D+\d*$/, true],
+        [/[^\w]+a*$/, true],
         [/\w+a*$/, false],
         [/[\w]+a*$/, false],
         [/[\w]+[^\w]a*$/, true],
@@ -423,6 +427,37 @@ describe('RedosDetector', () => {
         [/[E-c]?d?$/i, true],
         [/[E-c]?e?$/i, false],
         [/[^a]?A?$/i, true],
+
+        // character class escape expansions
+        [/.?a?$/, false],
+        [/.?[\n\r\u2028\u2029]?$/, true],
+        [/.?[\n\r\u2028\u2029]?$/, true],
+        [/\d?[^0-9]?$/, true],
+        [/\d?[0-9]?$/, false],
+        [/\D?[0-9]?$/, true],
+        [/\D?[^0-9]?$/, false],
+        [/\w?[^A-Za-z0-9_]?$/, true],
+        [/\w?[A-Za-z0-9_]?$/, false],
+        [/\W?[A-Za-z0-9_]?$/, true],
+        [/\W?[^A-Za-z0-9_]?$/, false],
+        [
+          /\s?[^\f\n\r\t\v\u0020\u00a0\u1680\u2000-\u200a\u2028-\u2029\u202f\u205f\u3000\ufeff]?$/,
+          true,
+        ],
+        [
+          /\s?[\f\n\r\t\v\u0020\u00a0\u1680\u2000-\u200a\u2028-\u2029\u202f\u205f\u3000\ufeff]?$/,
+          false,
+        ],
+        [
+          /\S?[\f\n\r\t\v\u0020\u00a0\u1680\u2000-\u200a\u2028-\u2029\u202f\u205f\u3000\ufeff]?$/,
+          true,
+        ],
+        [
+          /\S?[^\f\n\r\t\v\u0020\u00a0\u1680\u2000-\u200a\u2028-\u2029\u202f\u205f\u3000\ufeff]?$/,
+          false,
+        ],
+        [/.?[\n\r\u2028-\u2029]?$/, true],
+        [/.?[^\n\r\u2028-\u2029]?$/, false],
       ];
 
       cases.forEach(([regex, expectNoBacktracks]) => {


### PR DESCRIPTION
Before this change we would not resolve character class escapes (with the exception of `\d`) to their possible values.

This meant that a pattern like `/\w+\W+/` would be considered vulnerable even though `/[a-zA-Z0-9_]+[^a-zA-Z0-9_]+/` would not, because it didn't know that there was no overlap in possible values between `\w` and `\W`. _Note there was some logic that would cancel out exact inversions if it was written like `/\w+[^\w]+/`._

All none unicode character class escapes are now resolved to their possible values.

Unicode escapes are not expanded, and I'm not sure how to safely support those given the contents of different unicode properties can change over time when new unicode versions are released. Also there's currently no api to ask the browser what version of unicode it's on or what the contents of a unicode property are.

This now means `/^[\w+-]+(?:\.[\w+-]+)*@[\da-zA-Z]+(?:[.-][\da-zA-Z]+)*\.[a-zA-Z]{2,}$/u` used in some places for validating email addresses is now marked as safe, where it previously wasn't.