### PR TITLE
Do not support the `s` flag

### DIFF
--- a/src/redos-detector.test.ts
+++ b/src/redos-detector.test.ts
@@ -599,7 +599,7 @@ describe('RedosDetector', () => {
       expect(() => isSafe(/a/m)).toThrowError('Unsupported flag: m');
     });
 
-    ['u', 'g', 's', 'y', 'i'].forEach((flag) => {
+    ['u', 'g', 'y', 'i'].forEach((flag) => {
       it(`supports the "${flag}" flag`, () => {
         expect(() => isSafe(new RegExp('a', flag))).not.toThrowError();
       });

--- a/src/redos-detector.ts
+++ b/src/redos-detector.ts
@@ -226,13 +226,7 @@ export const defaultMaxBacktracks = 200;
 export const defaultMaxSteps = 20000;
 export const defaultUnicode = false;
 export const defaultCaseInsensitive = false;
-const supportedJSFlags: ReadonlySet<string> = new Set([
-  'u',
-  'g',
-  's',
-  'y',
-  'i',
-]);
+const supportedJSFlags: ReadonlySet<string> = new Set(['u', 'g', 'y', 'i']);
 
 type PatternWithAtomicGroupOffsets = Readonly<{
   atomicGroupOffsets: ReadonlySet<number>;


### PR DESCRIPTION
The `s` flag is not currently supported, but was incorrectly allowed. Not it will throw an exception if provided.