### PR TITLE
Support `dotAll` mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ The following options exist for both the library and CLI:
 
 - `caseInsensitive`: Enable case insensitive mode. _(Default: `false`)_
 - `unicode`: Enable unicode mode. _(Default: `false`)_
+- `dotAll`: Enable dot-all mode, which allows `.` to match new lines. _(Default: `false`)_
 - `maxBacktracks`: If worst case count of possible backtracks is above this number, the regex will be considered unsafe. _(Default: `200`)_
 - `maxSteps`: The maximum number of steps to make. Every time a new node is read from the pattern this counts as one step. If this limit is hit `error` will be `hitMaxSteps`. _(Default: `20000`)_
 - `timeout`: The maximum amount of time (ms) to spend processing. Once this time is passed the trails found so far will be returned, and the `error` will be `timeout`. _(Default: `Infinity`)_
@@ -169,7 +170,7 @@ _Note it's possible for there to be a infinite number of results, so you should 
 ### CLI
 
 ```sh
-$ npx redos-detector check "<regex pattern>" (--caseInsensitive) (--unicode) (--maxBacktracks <number>) (--maxSteps <number>) (--timeout <number>) (--alwaysIncludeTrails) (--disableDowngrade) (--resultsLimit <number>) (--json)
+$ npx redos-detector check "<regex pattern>" (--caseInsensitive) (--unicode) (--dotAll) (--maxBacktracks <number>) (--maxSteps <number>) (--timeout <number>) (--alwaysIncludeTrails) (--disableDowngrade) (--resultsLimit <number>) (--json)
 ```
 
 to run on the fly or
@@ -195,7 +196,7 @@ $ npm install redos-detector
 The following functions are provided:
 
 - `isSafe(regexp: RegExp, options?: { maxBacktracks?: number, maxSteps?: number, timeout?: number, downgradePattern?: boolean })`: This takes a [`RegExp`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp). The `i` and `u` flags are supported.
-- `isSafePattern(pattern: string, options?: { maxBacktracks?: number, maxSteps?: number, timeout?: number, downgradePattern?: boolean, caseInsensitive?: boolean, unicode?: boolean })`: This takes just the pattern as a string. E.g. `a*`.
+- `isSafePattern(pattern: string, options?: { maxBacktracks?: number, maxSteps?: number, timeout?: number, downgradePattern?: boolean, caseInsensitive?: boolean, unicode?: boolean, dotAll?: boolean })`: This takes just the pattern as a string. E.g. `a*`.
 - `downgradePattern(input: { pattern: string, unicode: boolean }`: This downgrades the provided pattern to one which is supported. You won't need to use this unless you set the `downgradePattern` option to `false`.
 
 ## Useful Resources

--- a/src/character-reader/character-reader-level-0.ts
+++ b/src/character-reader/character-reader-level-0.ts
@@ -77,9 +77,11 @@ export type CharacterReader = Reader<CharacterReaderValue>;
 
 export function buildCharacterReader({
   caseInsensitive,
+  dotAll,
   node,
 }: {
   caseInsensitive: boolean;
+  dotAll: boolean;
   node: MyRootNode;
 }): CharacterReader {
   switch (node.type) {
@@ -96,17 +98,18 @@ export function buildCharacterReader({
     case 'value':
       return buildValueCharacterReader({ caseInsensitive, node });
     case 'dot':
-      return buildDotCharacterReader(node);
+      return buildDotCharacterReader({ dotAll, node });
     case 'alternative':
       return buildSequenceCharacterReader({
         caseInsensitive,
+        dotAll,
         nodes: node.body,
       });
     case 'disjunction':
-      return buildDisjunctionCharacterReader({ caseInsensitive, node });
+      return buildDisjunctionCharacterReader({ caseInsensitive, dotAll, node });
     case 'group':
-      return buildGroupCharacterReader({ caseInsensitive, node });
+      return buildGroupCharacterReader({ caseInsensitive, dotAll, node });
     case 'quantifier':
-      return buildQuantifierCharacterReader({ caseInsensitive, node });
+      return buildQuantifierCharacterReader({ caseInsensitive, dotAll, node });
   }
 }

--- a/src/character-reader/character-reader-level-1.ts
+++ b/src/character-reader/character-reader-level-1.ts
@@ -96,9 +96,11 @@ export type CharacterReaderLevel1 = Reader<
  */
 export function buildCharacterReaderLevel1({
   caseInsensitive,
+  dotAll,
   node,
 }: {
   caseInsensitive: boolean;
+  dotAll: boolean;
   node: MyRootNode;
 }): CharacterReaderLevel1 {
   const startThread = function* (
@@ -172,5 +174,8 @@ export function buildCharacterReaderLevel1({
     return { bounded: false, preceedingZeroWidthEntries };
   };
 
-  return startThread(buildCharacterReader({ caseInsensitive, node }), []);
+  return startThread(
+    buildCharacterReader({ caseInsensitive, dotAll, node }),
+    [],
+  );
 }

--- a/src/character-reader/character-reader-level-2.ts
+++ b/src/character-reader/character-reader-level-2.ts
@@ -298,10 +298,12 @@ function* getGroupContentsReader({
  */
 export function buildCharacterReaderLevel2({
   caseInsensitive,
+  dotAll,
   node,
   nodeExtra,
 }: {
   caseInsensitive: boolean;
+  dotAll: boolean;
   node: MyRootNode;
   nodeExtra: NodeExtra;
 }): CharacterReaderLevel2 {
@@ -573,7 +575,7 @@ export function buildCharacterReaderLevel2({
   return startThread({
     characterReader: buildForkableReader(
       characterReaderLevel1ToInternalReader(
-        buildCharacterReaderLevel1({ caseInsensitive, node }),
+        buildCharacterReaderLevel1({ caseInsensitive, dotAll, node }),
       ),
     ),
     groupContentsStore: new Map(),

--- a/src/character-reader/character-reader-level-3.ts
+++ b/src/character-reader/character-reader-level-3.ts
@@ -165,10 +165,12 @@ function* isReaderUnbounded(
  */
 export function buildCharacterReaderLevel3({
   caseInsensitive,
+  dotAll,
   node,
   nodeExtra,
 }: {
   caseInsensitive: boolean;
+  dotAll: boolean;
   node: MyRootNode;
   nodeExtra: NodeExtra;
 }): CharacterReaderLevel3 {
@@ -227,7 +229,7 @@ export function buildCharacterReaderLevel3({
 
   return startThread(
     buildForkableReader(
-      buildCharacterReaderLevel2({ caseInsensitive, node, nodeExtra }),
+      buildCharacterReaderLevel2({ caseInsensitive, dotAll, node, nodeExtra }),
     ),
   );
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,6 +31,7 @@ program
   .command('check')
   .argument('<regex pattern>', 'the regex pattern')
   .option('--caseInsensitive', 'enable case insensitive mode', false)
+  .option('--dotAll', 'enable dot-all mode', false)
   .option('--unicode', 'enable unicode mode', false)
   .option(
     '--maxBacktracks <number>',
@@ -74,11 +75,13 @@ program
         resultsLimit,
         timeout,
         caseInsensitive,
+        dotAll,
         unicode,
       }: {
         alwaysIncludeTrails: boolean;
         caseInsensitive: boolean;
         disableDowngrade: boolean;
+        dotAll: boolean;
         json: boolean;
         maxBacktracks: number;
         maxSteps: number;
@@ -90,6 +93,7 @@ program
       try {
         const result = isSafePattern(pattern, {
           caseInsensitive,
+          dotAll,
           downgradePattern: !disableDowngrade,
           maxBacktracks: coerceInfinity(maxBacktracks),
           maxSteps: coerceInfinity(maxSteps),

--- a/src/collect-results.ts
+++ b/src/collect-results.ts
@@ -22,6 +22,7 @@ export type WalkerResult = Readonly<{
 export type CollectResultsInput = Readonly<{
   atomicGroupOffsets: ReadonlySet<number>;
   caseInsensitive: boolean;
+  dotAll: boolean;
   maxBacktracks: number;
   maxSteps: number;
   node: MyRootNode;
@@ -35,18 +36,17 @@ export function collectResults({
   maxSteps,
   timeout,
   caseInsensitive,
+  dotAll,
 }: CollectResultsInput): WalkerResult {
   const nodeExtra = buildNodeExtra(node);
-  const leftStreamReader = buildCharacterReaderLevel3({
+  const input = {
     caseInsensitive,
+    dotAll,
     node,
     nodeExtra,
-  });
-  const rightStreamReader = buildCharacterReaderLevel3({
-    caseInsensitive,
-    node,
-    nodeExtra,
-  });
+  };
+  const leftStreamReader = buildCharacterReaderLevel3(input);
+  const rightStreamReader = buildCharacterReaderLevel3(input);
   const reader = buildCheckerReader({
     atomicGroupOffsets,
     leftStreamReader,

--- a/src/nodes/disjunction.ts
+++ b/src/nodes/disjunction.ts
@@ -9,9 +9,11 @@ import { MyFeatures } from '../parse';
 
 export function buildDisjunctionCharacterReader({
   caseInsensitive,
+  dotAll,
   node,
 }: {
   caseInsensitive: boolean;
+  dotAll: boolean;
   node: Disjunction<MyFeatures>;
 }): CharacterReader {
   return chainReaders([
@@ -19,7 +21,7 @@ export function buildDisjunctionCharacterReader({
       node.body.slice(0, -1).map((part) => {
         return {
           reader: (): CharacterReader =>
-            buildCharacterReader({ caseInsensitive, node: part }),
+            buildCharacterReader({ caseInsensitive, dotAll, node: part }),
           subType: null,
           type: characterReaderTypeSplit,
         };
@@ -27,6 +29,7 @@ export function buildDisjunctionCharacterReader({
     ),
     buildCharacterReader({
       caseInsensitive,
+      dotAll,
       node: node.body[node.body.length - 1],
     }),
   ]);

--- a/src/nodes/dot.ts
+++ b/src/nodes/dot.ts
@@ -4,16 +4,24 @@ import {
 } from '../character-reader/character-reader-level-0';
 import { Dot } from 'regjsparser';
 
-export function* buildDotCharacterReader(node: Dot): CharacterReader {
+export function* buildDotCharacterReader({
+  dotAll,
+  node,
+}: {
+  dotAll: boolean;
+  node: Dot;
+}): CharacterReader {
   yield {
     characterGroups: {
       negated: true,
-      // [\n\r\u2028-\u2029]
-      ranges: [
-        [10, 10],
-        [13, 13],
-        [8232, 8233],
-      ],
+      ranges: dotAll
+        ? []
+        : // [\n\r\u2028-\u2029]
+          [
+            [10, 10],
+            [13, 13],
+            [8232, 8233],
+          ],
       unicodePropertyEscapes: new Set(),
     },
     node,

--- a/src/nodes/group.ts
+++ b/src/nodes/group.ts
@@ -58,9 +58,11 @@ export function getLookaheadStack(stack: Stack): LookaheadStack {
 
 export function buildGroupCharacterReader({
   caseInsensitive,
+  dotAll,
   node,
 }: {
   caseInsensitive: boolean;
+  dotAll: boolean;
   node: Group<MyFeatures>;
 }): CharacterReader {
   switch (node.behavior) {
@@ -76,6 +78,7 @@ export function buildGroupCharacterReader({
                 map(
                   buildSequenceCharacterReader({
                     caseInsensitive,
+                    dotAll,
                     nodes: node.body,
                   }),
                   (value) => {
@@ -95,7 +98,11 @@ export function buildGroupCharacterReader({
     case 'ignore':
     case 'normal': {
       return map(
-        buildSequenceCharacterReader({ caseInsensitive, nodes: node.body }),
+        buildSequenceCharacterReader({
+          caseInsensitive,
+          dotAll,
+          nodes: node.body,
+        }),
         (value) => {
           return {
             ...value,

--- a/src/nodes/quantifier.ts
+++ b/src/nodes/quantifier.ts
@@ -63,9 +63,11 @@ export function buildQuantifierTrail(
 
 export function buildQuantifierCharacterReader({
   caseInsensitive,
+  dotAll,
   node,
 }: {
   caseInsensitive: boolean;
+  dotAll: boolean;
   node: Quantifier<MyFeatures>;
 }): CharacterReader {
   const { min, max = Infinity } = node;
@@ -92,7 +94,11 @@ export function buildQuantifierCharacterReader({
                   ]
                 : []),
               (): CharacterReader =>
-                buildCharacterReader({ caseInsensitive, node: node.body[0] }),
+                buildCharacterReader({
+                  caseInsensitive,
+                  dotAll,
+                  node: node.body[0],
+                }),
             ]),
             (value) => {
               const inInfinitePortion = i >= min && i >= 1 && max === Infinity;

--- a/src/nodes/sequence.ts
+++ b/src/nodes/sequence.ts
@@ -7,15 +7,17 @@ import { MyRootNode } from '../parse';
 
 export function buildSequenceCharacterReader({
   caseInsensitive,
+  dotAll,
   nodes,
 }: {
   caseInsensitive: boolean;
+  dotAll: boolean;
   nodes: readonly MyRootNode[];
 }): CharacterReader {
   return joinArray(
     nodes.map((node) => {
       return (): CharacterReader =>
-        buildCharacterReader({ caseInsensitive, node });
+        buildCharacterReader({ caseInsensitive, dotAll, node });
     }),
   );
 }

--- a/src/redos-detector.test.ts
+++ b/src/redos-detector.test.ts
@@ -428,6 +428,10 @@ describe('RedosDetector', () => {
         [/[E-c]?e?$/i, false],
         [/[^a]?A?$/i, true],
 
+        // dotAll
+        [/.?[\r\n\u2028-\u2029].?$/, true],
+        [/.?[\r\n\u2028-\u2029].?$/s, false],
+
         // character class escape expansions
         [/.?a?$/, false],
         [/.?[\n\r\u2028\u2029]?$/, true],
@@ -611,7 +615,7 @@ describe('RedosDetector', () => {
       expect(() => isSafe(/a/m)).toThrowError('Unsupported flag: m');
     });
 
-    ['u', 'g', 'y', 'i'].forEach((flag) => {
+    ['u', 'g', 's', 'y', 'i'].forEach((flag) => {
       it(`supports the "${flag}" flag`, () => {
         expect(() => isSafe(new RegExp('a', flag))).not.toThrowError();
       });

--- a/src/redos-detector.ts
+++ b/src/redos-detector.ts
@@ -216,6 +216,10 @@ export type IsSafePatternConfig = IsSafeConfig & {
    */
   readonly caseInsensitive?: boolean;
   /**
+   * Enable dot-all mode, which allows `.` to match new lines.
+   */
+  readonly dotAll?: boolean;
+  /**
    * Enable unicode mode.
    */
   readonly unicode?: boolean;
@@ -226,7 +230,14 @@ export const defaultMaxBacktracks = 200;
 export const defaultMaxSteps = 20000;
 export const defaultUnicode = false;
 export const defaultCaseInsensitive = false;
-const supportedJSFlags: ReadonlySet<string> = new Set(['u', 'g', 'y', 'i']);
+export const defaultDotAll = false;
+const supportedJSFlags: ReadonlySet<string> = new Set([
+  'u',
+  'g',
+  's',
+  'y',
+  'i',
+]);
 
 type PatternWithAtomicGroupOffsets = Readonly<{
   atomicGroupOffsets: ReadonlySet<number>;
@@ -276,6 +287,7 @@ export function isSafePattern(
     maxSteps = defaultMaxSteps,
     timeout = defaultTimeout,
     caseInsensitive = defaultCaseInsensitive,
+    dotAll = defaultDotAll,
     unicode = defaultUnicode,
     downgradePattern = true,
   }: IsSafePatternConfig = {},
@@ -314,6 +326,7 @@ export function isSafePattern(
   const result = collectResults({
     atomicGroupOffsets,
     caseInsensitive,
+    dotAll,
     maxBacktracks,
     maxSteps,
     node: ast,
@@ -378,6 +391,7 @@ export function isSafe(
 ): RedosDetectorResult {
   let unicode = false;
   let caseInsensitive = false;
+  let dotAll = false;
   for (const flag of regexp.flags.split('')) {
     if (!supportedJSFlags.has(flag)) {
       throw new Error(`Unsupported flag: ${flag}`);
@@ -388,7 +402,15 @@ export function isSafe(
     if (flag === 'i') {
       caseInsensitive = true;
     }
+    if (flag === 's') {
+      dotAll = true;
+    }
   }
 
-  return isSafePattern(regexp.source, { ...config, caseInsensitive, unicode });
+  return isSafePattern(regexp.source, {
+    ...config,
+    caseInsensitive,
+    dotAll,
+    unicode,
+  });
 }


### PR DESCRIPTION
This adds a new `dotAll` option to `isSafePattern` and supports the `s` flag for expressions passed to `isSafe`.