### PR TITLE
Always stop expanding quantifier after min iterations after loop detected

### DIFF
--- a/src/checker-reader.ts
+++ b/src/checker-reader.ts
@@ -34,6 +34,7 @@ import { areSetsEqual } from './sets';
 import { buildQuantifiersInInfinitePortion } from './nodes/quantifier';
 import { fork } from 'forkable-iterator';
 import { last } from './arrays';
+import { NodeExtra } from './node-extra';
 import { once } from './once';
 
 export type CheckerInput = Readonly<{
@@ -43,6 +44,7 @@ export type CheckerInput = Readonly<{
   multiLine: boolean;
   rightStreamReader: CharacterReaderLevel2;
   timeout: number;
+  nodeExtra: NodeExtra;
 }>;
 
 export type CharacterGroupsOrReference = Readonly<
@@ -322,7 +324,7 @@ export function* buildCheckerReader(input: CheckerInput): CheckerReader {
     trail = [...trail, newEntry];
 
     const leftQuantifiersInInfiniteProportion =
-      buildQuantifiersInInfinitePortion(leftValue.stack);
+      buildQuantifiersInInfinitePortion(leftValue.stack, input.nodeExtra);
 
     if (leftQuantifiersInInfiniteProportion.size > 0) {
       const leftAndRightIdentical = trail.every(

--- a/src/collect-results.ts
+++ b/src/collect-results.ts
@@ -132,6 +132,7 @@ export function collectResults({
     leftStreamReader,
     maxSteps,
     multiLine,
+    nodeExtra,
     rightStreamReader,
     timeout,
   });

--- a/src/downgrade-pattern.test.ts
+++ b/src/downgrade-pattern.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-useless-backreference, redos-detector/no-unsafe-regex */
+/* eslint-disable no-useless-backreference */
 import {
   DowngradedRegexPattern,
   downgradePattern,

--- a/src/redos-detector.test.ts
+++ b/src/redos-detector.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-control-regex, no-useless-backreference, redos-detector/no-unsafe-regex */
+/* eslint-disable no-control-regex, no-useless-backreference */
 import {
   downgradePattern,
   isSafe,
@@ -18,8 +18,11 @@ describe('RedosDetector', () => {
 
   describe('isSafe', () => {
     describe('cases', () => {
-      type Case = [RegExp, boolean];
-      type CaseWithFlags = [...Case, Set<'ignoreSnapshot' | 'missingAnchor'>];
+      type Case = [RegExp, boolean | number];
+      type CaseWithFlags = [
+        ...Case,
+        Set<'ignoreSnapshot' | 'missingAnchor' | 'infinite'>,
+      ];
 
       const cases: (Case | CaseWithFlags)[] = [
         [/^()/, true],
@@ -509,15 +512,36 @@ describe('RedosDetector', () => {
         [/(a+)+a/, false, new Set(['missingAnchor'])],
         [/(a|aa)/, false, new Set(['missingAnchor'])],
 
+        // group containing quantifier referenced later, so all quantifier iterations emitted
+        [/^(a{0,3}bc)x\1*(aaabc)*$/, false, new Set(['infinite'])],
+        [/^((a{0,3})bc)x\1*(aaabc)*$/, false, new Set(['infinite'])],
+
         // GH issues
         // https://github.com/tjenkinson/redos-detector/issues/621
         [/\s+/, true, new Set(['missingAnchor'])],
         // https://github.com/tjenkinson/redos-detector/issues/606
         [/(a+)+/, true, new Set(['missingAnchor'])],
         [/(a+)+$/, false, new Set(['missingAnchor'])],
+        // https://github.com/tjenkinson/redos-detector/issues/650
+        [
+          /^(?:-(?:[a-z][a-z\d]{4,7}|\d[a-z\d]{3,7}))*(?:_[^x](?:_[a-z\d]{2}(_[a-z\d]{3,8})*)+)?$/,
+          2,
+        ],
+        [
+          /^(?:-(?:[a-z][a-z\d]{4,7}|\d[a-z\d]{3,7}))*(?:_[^x](?:_[a-z\d]{2}(_[a-z\d]{3,8}){0,5})+)?$/,
+          2,
+        ],
+        [
+          /^(?:-(?:[a-z][a-z\d]{4,7}|\d[a-z\d]{3,7}))*(?:_[^x](?:_[a-z\d]{2}(_[a-z\d]{3,8}){0,2})+)?$/,
+          2,
+        ],
+        [
+          /^(?:-(?:[a-z][a-z\d]{4,7}|\d[a-z\d]{3,7}))*(?:_[^x](?:_[a-z\d]{2}(_[a-z\d]{3,8}){0,2}){1,5})?$/,
+          2,
+        ],
       ];
 
-      cases.forEach(([regex, expectNoBacktracks, flags = new Set()]) => {
+      cases.forEach(([regex, expectNoBacktracksOrScore, flags = new Set()]) => {
         const source =
           typeof regex === 'string' ? regex : `/${regex.source}/${regex.flags}`;
 
@@ -528,20 +552,31 @@ describe('RedosDetector', () => {
           });
           const { error, trails, safe, score } = result;
 
-          if (expectNoBacktracks) {
+          if (expectNoBacktracksOrScore === true) {
             expect(error).toBe(null);
           }
           expect(error).toMatchSnapshot();
 
-          expect(trails.length === 0).toBe(expectNoBacktracks);
-          if (expectNoBacktracks) {
+          expect(trails.length === 0).toBe(expectNoBacktracksOrScore === true);
+          if (expectNoBacktracksOrScore === true) {
             expect(score).toStrictEqual({
               infinite: false,
               value: 1,
             });
+          } else if (typeof expectNoBacktracksOrScore === 'number') {
+            expect(score).toStrictEqual({
+              infinite: false,
+              value: expectNoBacktracksOrScore,
+            });
           } else {
             expect(score).toMatchSnapshot();
           }
+          if (flags.has('infinite')) {
+            expect(score).toStrictEqual({
+              infinite: true,
+            });
+          }
+
           expect(safe).toBe(!error);
 
           if (!flags.has('ignoreSnapshot')) {


### PR DESCRIPTION
...unless the quantifier is part of a group that is referenced later.

Previously if there was a max then we would always generate up to the max iterations. If the max was infinity then we would stop once the sequence of the left against right hit an infinite loop.

Now we always stop when the sequence of left against right hits an infinite loop, once the min has been reached, unless it's part of a group referenced later.

Closes https://github.com/tjenkinson/redos-detector/issues/650