### PR TITLE
Respect inverted unicode property escape in character class

### DIFF
--- a/src/is-unbounded-reader.ts
+++ b/src/is-unbounded-reader.ts
@@ -35,7 +35,6 @@ type StackFrame = Readonly<{
 }>;
 
 const notNewLine: CharacterGroups = {
-  negated: true,
   ranges:
     // [\n\r\u2028-\u2029]
     [
@@ -43,7 +42,8 @@ const notNewLine: CharacterGroups = {
       [13, 13],
       [8232, 8233],
     ],
-  unicodePropertyEscapes: new Set(),
+  rangesNegated: true,
+  unicodePropertyEscapes: new Map(),
 };
 
 /*

--- a/src/nodes/character-class-escape.ts
+++ b/src/nodes/character-class-escape.ts
@@ -65,9 +65,9 @@ export function* buildCharacterClassEscapeReader(
   const ranges = characterClassEscapeToRange(value);
   yield {
     characterGroups: {
-      negated: false,
       ranges,
-      unicodePropertyEscapes: new Set(),
+      rangesNegated: false,
+      unicodePropertyEscapes: new Map(),
     },
     node,
     stack: [],

--- a/src/nodes/dot.ts
+++ b/src/nodes/dot.ts
@@ -13,7 +13,6 @@ export function* buildDotCharacterReader({
 }): CharacterReader {
   yield {
     characterGroups: {
-      negated: true,
       ranges: dotAll
         ? []
         : // [\n\r\u2028-\u2029]
@@ -22,7 +21,8 @@ export function* buildDotCharacterReader({
             [13, 13],
             [8232, 8233],
           ],
-      unicodePropertyEscapes: new Set(),
+      rangesNegated: true,
+      unicodePropertyEscapes: new Map(),
     },
     node,
     stack: [],

--- a/src/nodes/unicode-property-escape.ts
+++ b/src/nodes/unicode-property-escape.ts
@@ -12,9 +12,9 @@ export function buildUnicodePropertyEscapeCharacterReader(
   return buildArrayReader<CharacterReaderValueGroups>([
     {
       characterGroups: {
-        negated: node.negative,
         ranges: [],
-        unicodePropertyEscapes: new Set([node.value]),
+        rangesNegated: false,
+        unicodePropertyEscapes: new Map([[node.value, node.negative]]),
       },
       node,
       stack: [],

--- a/src/nodes/value.ts
+++ b/src/nodes/value.ts
@@ -30,9 +30,9 @@ export function buildValueCharacterReader({
   return buildArrayReader<CharacterReaderValueGroups>([
     {
       characterGroups: {
-        negated: false,
         ranges: [[codePoint, codePoint]],
-        unicodePropertyEscapes: new Set(),
+        rangesNegated: false,
+        unicodePropertyEscapes: new Map(),
       },
       node,
       stack: [],

--- a/src/redos-detector.test.ts
+++ b/src/redos-detector.test.ts
@@ -499,6 +499,28 @@ describe('RedosDetector', () => {
         [/^a?a?[\n\r\u2028-\u2029]{2}/m, true],
         [/^a?a?[\n\r\u2028-\u2029]{2}$/m, false],
 
+        // unicode character class escapes
+        [/^\p{Lowercase_Letter}?\p{Lowercase_Letter}?$/u, false],
+        [/^\P{Lowercase_Letter}?\P{Lowercase_Letter}?$/u, false],
+        [/^\p{Lowercase_Letter}?\P{Lowercase_Letter}?$/u, true],
+        [/^\P{Lowercase_Letter}?\p{Lowercase_Letter}?$/u, true],
+        [/^\P{Lowercase_Letter}?\p{Lowercase_Letter}?a?$/u, false],
+        [/^[\p{Lowercase_Letter}]?[\p{Lowercase_Letter}]?$/u, false],
+        [/^[\P{Lowercase_Letter}]?[\P{Lowercase_Letter}]?$/u, false],
+        [/^[\p{Lowercase_Letter}]?[\P{Lowercase_Letter}]?$/u, true],
+        [/^[\P{Lowercase_Letter}]?[\p{Lowercase_Letter}]?$/u, true],
+        [/^[\p{Lowercase_Letter}]?[^\p{Lowercase_Letter}]?$/u, true],
+        [/^[\P{Lowercase_Letter}]?[^\P{Lowercase_Letter}]?$/u, true],
+        [
+          /^[\p{Lowercase_Letter}]?[\P{Lowercase_Letter}\p{Lowercase_Letter}]?$/u,
+          false,
+        ],
+        [
+          /^[\p{Lowercase_Letter}]?[\p{Lowercase_Letter}\P{Lowercase_Letter}]?$/u,
+          false,
+        ],
+        [/^\P{Lowercase_Letter}?a?$/u, false],
+
         // no start anchor
         [/a/, true, new Set(['missingAnchor'])],
         [/a*a*/, true, new Set(['missingAnchor'])],


### PR DESCRIPTION
Fixes `^[\P{Lowercase_Letter}]?[\p{Lowercase_Letter}]?$`. The `\P` was being treated as if it was `\p`.